### PR TITLE
Rotate expired JWT tokens

### DIFF
--- a/apps/sso/components/jwtissuer/component.go
+++ b/apps/sso/components/jwtissuer/component.go
@@ -2,14 +2,19 @@ package jwtissuer
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/justinsb/kweb/components"
 	"github.com/justinsb/kweb/components/cookies"
 	"github.com/justinsb/kweb/components/keystore"
 	"github.com/justinsb/kweb/components/users"
+	userapi "github.com/justinsb/kweb/components/users/pb"
+	"golang.org/x/oauth2/jws"
 	"k8s.io/klog/v2"
 )
 
@@ -20,49 +25,83 @@ type JWTIssuerComponent struct {
 
 	Issuer   string
 	Audience string
+
+	CookieDomain string
 }
 
 var _ components.RequestFilter = &JWTIssuerComponent{}
 
 func (c *JWTIssuerComponent) ProcessRequest(ctx context.Context, req *components.Request, next components.RequestFilterChain) (components.Response, error) {
+	log := klog.FromContext(ctx)
+
+	jwtCookie, err := req.Cookie(CookieNameJWT)
+	if err != nil && err != http.ErrNoCookie {
+		return nil, fmt.Errorf("error reading cookie: %w", err)
+	}
+
+	jwtCookieValue := ""
+	if jwtCookie != nil {
+		jwtCookieValue = jwtCookie.Value
+	}
+	jwtCookieValue = strings.TrimPrefix(jwtCookieValue, "Bearer ")
+
 	user := users.GetUser(ctx)
 
-	if user != nil {
-		jwtCookie, err := req.Cookie(CookieNameJWT)
-		if err != nil && err != http.ErrNoCookie {
-			return nil, fmt.Errorf("error reading cookie: %w", err)
+	setJWT := false
+	if jwtCookieValue != "" {
+		minTTL := 5 * time.Minute
+		if reason := c.jwtIsExpiredOrInvalid(ctx, jwtCookieValue, user, minTTL); reason != "" {
+			log.Info("jwt is not valid/is expiring soon; will replace", "reason", reason)
+			// If the JWT is bad, we should either replace or remove it
+			setJWT = true
 		}
-		if jwtCookie == nil || jwtCookie.Value == "" {
+	}
+
+	if user != nil && jwtCookieValue == "" {
+		setJWT = true
+	}
+
+	if setJWT {
+		setCookie := http.Cookie{
+			Name:     CookieNameJWT,
+			HttpOnly: true,
+			Secure:   true,
+			Path:     "/", // Otherwise cookie is filtered
+		}
+
+		if user != nil {
 			scopes := []string{"sso"}
-			expiration := time.Hour // while we're developing
-			token, err := c.buildToken(user.GetMetadata().GetName(), scopes, expiration)
+			jwtExpiration := time.Hour // while we're developing
+			// The istio jwt rule is not very easy to work with,
+			// when the cookie has expired it blocks everything,
+			// and it's surprisingly tricky to allowlist just one app
+			cookieExpiration := jwtExpiration - 5*time.Minute
+
+			setCookie.Expires = time.Now().Add(cookieExpiration)
+
+			token, err := c.buildJWTToken(user.GetMetadata().GetName(), scopes, jwtExpiration)
 			if err != nil {
 				return nil, fmt.Errorf("error building JWT token: %w", err)
 			}
-
-			setCookie := http.Cookie{
-				Name:     CookieNameJWT,
-				Value:    token.TokenType + " " + token.AccessToken,
-				Expires:  time.Now().Add(time.Hour * 24 * 365),
-				HttpOnly: true,
-				Secure:   true,
-				Path:     "/", // Otherwise cookie is filtered
-			}
-
-			// TODO: Set domain
-			// setCookie.Domain = ...
-
-			if !req.BrowserUsingHTTPS() {
-				if req.IsLocalhost() {
-					klog.Warningf("setting cookie to _not_ be secure, because running on localhost")
-					setCookie.Secure = false
-				} else {
-					klog.Warningf("session invoked but running without TLS (and not on localhost); likely won't work")
-				}
-			}
-
-			cookies.SetCookie(ctx, setCookie)
+			setCookie.Value = token.TokenType + " " + token.AccessToken
+		} else {
+			setCookie.Expires = time.Unix(0, 0)
 		}
+
+		if c.CookieDomain != "" {
+			setCookie.Domain = c.CookieDomain
+		}
+
+		if !req.BrowserUsingHTTPS() {
+			if req.IsLocalhost() {
+				klog.Warningf("setting cookie to _not_ be secure, because running on localhost")
+				setCookie.Secure = false
+			} else {
+				klog.Warningf("session invoked but running without TLS (and not on localhost); likely won't work")
+			}
+		}
+
+		cookies.SetCookie(ctx, setCookie)
 	}
 
 	return next(ctx, req)
@@ -72,4 +111,47 @@ func (c *JWTIssuerComponent) RegisterHandlers(s *components.Server, mux *http.Se
 	mux.HandleFunc("/.well-known/openid-configuration", s.ServeHTTP(c.ServeOpenIDConfiguration))
 	mux.HandleFunc("/.oidc/jwks", s.ServeHTTP(c.ServeJWKS))
 	return nil
+}
+
+func (c *JWTIssuerComponent) jwtIsExpiredOrInvalid(ctx context.Context, jwt string, user *userapi.User, minTTL time.Duration) string {
+	log := klog.FromContext(ctx)
+	tokens := strings.Split(jwt, ".")
+	if len(tokens) != 3 {
+		log.Info("jwt did not have 3 components; treating as invalid")
+		return "corrupt"
+	}
+	b1, err := base64.RawStdEncoding.DecodeString(tokens[0])
+	if err != nil {
+		log.Info("jwt component 1 could not be base64 decoded; treating as invalid")
+		return "corrupt"
+	}
+	v1 := make(map[string]interface{})
+	if err := json.Unmarshal(b1, &v1); err != nil {
+		log.Info("jwt component 1 could not be unmarshaled as json; treating as invalid")
+		return "corrupt"
+	}
+
+	b2, err := base64.RawStdEncoding.DecodeString(tokens[1])
+	if err != nil {
+		log.Info("jwt claims could not be base64 decoded; treating as invalid")
+		return "corrupt"
+	}
+	var claims jws.ClaimSet
+	if err := json.Unmarshal(b2, &claims); err != nil {
+		log.Info("jwt claims could not be unmarshaled as json; treating as invalid")
+		return "corrupt"
+	}
+	log.Info("jwt", "component1", v1, "claims", claims)
+
+	if claims.Exp == 0 {
+		log.Info("jwt did not have expiry; treating as invalid")
+		return "expired"
+	}
+	expiresAtTime := time.Unix(claims.Exp, 0)
+	ttl := time.Until(expiresAtTime)
+	if ttl < minTTL {
+		log.Info("jwt expiring soon; marking JWT as invalid")
+		return "expiring"
+	}
+	return ""
 }

--- a/apps/sso/components/jwtissuer/token.go
+++ b/apps/sso/components/jwtissuer/token.go
@@ -14,7 +14,7 @@ import (
 )
 
 // buildToken creates a new JWT token
-func (c *JWTIssuerComponent) buildToken(userID string, scopes []string, expiration time.Duration) (*oauth2.Token, error) {
+func (c *JWTIssuerComponent) buildJWTToken(userID string, scopes []string, expiration time.Duration) (*oauth2.Token, error) {
 	var claims jws.ClaimSet
 	// email address of the client_id of the application making the access token request
 	claims.Iss = c.Issuer

--- a/apps/sso/components/oidclogin/oidc.go
+++ b/apps/sso/components/oidclogin/oidc.go
@@ -74,7 +74,6 @@ func (c *OIDCLoginComponent) userFromJWTToken(ctx context.Context, req *componen
 
 	var rawClaims map[string]interface{}
 	tokenInfo.token.Claims(&rawClaims)
-	klog.Infof("tokenInfo is %#v", tokenInfo.token)
 	klog.Infof("rawClaims is %#v", rawClaims)
 
 	userID := tokenInfo.token.Subject

--- a/apps/sso/k8s/manifest.yaml
+++ b/apps/sso/k8s/manifest.yaml
@@ -27,6 +27,8 @@ spec:
         envFrom:
         - secretRef:
             name: kweb-sso
+        - configMapRef:
+            name: kweb-sso
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
We also try to expire the cookie a bit before the JWT token expires,
to handle challenges with very strict gateways.
